### PR TITLE
13 scan des vulnérabilités dépendances avec owasp dependency check

### DIFF
--- a/.github/workflows/security-dependency-scan.yml
+++ b/.github/workflows/security-dependency-scan.yml
@@ -1,0 +1,42 @@
+name: Security Dependency Scan
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 4 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run tests and OWASP dependency scan
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        run: ./gradlew --no-daemon clean check
+
+      - name: Upload OWASP dependency report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: owasp-dependency-check-report
+          path: |
+            build/reports/dependency-check-report.html
+            build/reports/dependency-check-report.json
+          if-no-files-found: warn

--- a/.github/workflows/security-dependency-scan.yml
+++ b/.github/workflows/security-dependency-scan.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: '0 4 * * 1'
+    - cron: "0 4 * * 1"
 
 permissions:
   contents: read
@@ -21,15 +21,20 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: "21"
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Run tests and OWASP dependency scan
+      - name: Run tests and coverage check
+        run: ./gradlew --no-daemon clean test jacocoTestCoverageVerification
+
+      - name: Run OWASP dependency scan
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-        run: ./gradlew --no-daemon clean check
+          # 2g dédié uniquement à ce step : le scan NVD est volumineux en mémoire
+          GRADLE_OPTS: "-Xmx2048m -XX:MaxMetaspaceSize=512m"
+        run: ./gradlew --no-daemon dependencyCheckAnalyze
 
       - name: Upload OWASP dependency report
         if: always()

--- a/.github/workflows/security-dependency-scan.yml
+++ b/.github/workflows/security-dependency-scan.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Make Gradle wrapper executable
+        run: chmod +x ./gradlew
+
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Note sur la colonne `Missed Branches`:
 
 Detection automatique des vulnerabilites dans les dependances Maven.
 
-Generation du rapport:
+Generation du rapport en local:
 
 ```powershell
 .\gradlew.bat dependencyCheckAnalyze
@@ -218,6 +218,7 @@ Derniers resultats (20/03/2026):
 - Aucune vulnerabilite critique (CVSS >= 9.0) — build non bloque
 
 Dependances concernees:
+
 - `angus-activation 2.0.3` — CVE-2025-7962
 - `commons-lang3 3.17.0` — CVE-2025-48924
 - `hibernate-validator 8.0.3` — CVE-2025-15104
@@ -228,7 +229,14 @@ Intégration CI (GitHub Actions):
 
 - Scan automatique a chaque push, pull request et chaque lundi a 4h
 - Workflow: `.github/workflows/security-dependency-scan.yml`
-- Rapports HTML et JSON uploades comme artefacts de build
+- Tests et coverage executes dans une premiere etape (memoire standard)
+- Scan OWASP execute dans une etape dediee avec 2 Go de heap alloues via `GRADLE_OPTS`
+- Rapports HTML et JSON uploades comme artefacts de build (meme en cas d'echec)
+
+Configuration memoire:
+
+- Taches standard (compilation, tests, JaCoCo) : `Xmx1024m` (defini dans `gradle.properties`)
+- Scan OWASP uniquement : `Xmx2048m` (surcharge via `GRADLE_OPTS` dans le step CI dedie)
 
 ## Notes de projet
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,66 @@ Il valide explicitement les 3 cas suivants sur une route admin (`/admin/reservat
 - avec `ROLE_USER` -> `403 Forbidden`
 - avec `ROLE_ADMIN` -> `200 OK`
 
+## Couverture de code (JaCoCo)
+
+Generation du rapport:
+
+```powershell
+.\gradlew.bat clean check
+```
+
+Rapport HTML genere dans:
+
+- `build/reports/jacoco/test/html/index.html`
+
+Seuils verifies automatiquement:
+
+- Couverture globale >= `80%`
+- Couche service >= `80%`
+
+Note sur la colonne `Missed Branches`:
+
+- `n/a` signifie qu'il n'y a pas de branche mesurable dans la classe/methode (pas de `if/else`, `switch`, ternaire, etc.).
+- Ce n'est pas une erreur de couverture.
+
+## Scan des vulnérabilités (OWASP Dependency-Check)
+
+Detection automatique des vulnerabilites dans les dependances Maven.
+
+Generation du rapport:
+
+```powershell
+.\gradlew.bat dependencyCheckAnalyze
+```
+
+Rapports generes dans:
+
+- `build/reports/dependency-check-report.html` (rapport interactif)
+- `build/reports/dependency-check-report.json` (donnees brutes)
+
+Seuil critique configure:
+
+- Le build echoue si une dependance presente un CVE avec un score CVSS >= `9.0`
+- Les CVE de score inferieur sont reportees dans le rapport sans bloquer le build
+
+Derniers resultats (20/03/2026):
+
+- 8 vulnerabilites detectees, score CVSS maximum : **7.5**
+- Aucune vulnerabilite critique (CVSS >= 9.0) — build non bloque
+
+Dependances concernees:
+- `angus-activation 2.0.3` — CVE-2025-7962
+- `commons-lang3 3.17.0` — CVE-2025-48924
+- `hibernate-validator 8.0.3` — CVE-2025-15104
+- `log4j-api 2.24.3` — CVE-2025-68161
+- `swagger-ui 5.31.0` (DOMPurify 3.2.6) — CVE-2025-15599, CVE-2026-0540
+
+Intégration CI (GitHub Actions):
+
+- Scan automatique a chaque push, pull request et chaque lundi a 4h
+- Workflow: `.github/workflows/security-dependency-scan.yml`
+- Rapports HTML et JSON uploades comme artefacts de build
+
 ## Notes de projet
 
 - Le package Java utilise `com.shake_art.back` (underscore), car `com.shake-art.back` n'est pas valide.

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'org.springframework.boot' version '3.5.11'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'jacoco'
+	id 'org.owasp.dependencycheck' version '12.1.0'
 }
 
 group = 'com.shake-art'
@@ -59,6 +60,21 @@ jacoco {
 	toolVersion = '0.8.12'
 }
 
+dependencyCheck {
+	formats = ['HTML', 'JSON']
+	failBuildOnCVSS = 9.0
+	analyzers {
+		ossIndex {
+			enabled = false
+		}
+	}
+	if (System.getenv('NVD_API_KEY')) {
+		nvd {
+			apiKey = System.getenv('NVD_API_KEY')
+		}
+	}
+}
+
 tasks.named('jacocoTestReport') {
 	dependsOn(tasks.named('test'))
 	reports {
@@ -107,4 +123,5 @@ tasks.named('jacocoTestCoverageVerification') {
 
 tasks.named('check') {
 	dependsOn(tasks.named('jacocoTestCoverageVerification'))
+	dependsOn(tasks.named('dependencyCheckAnalyze'))
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 # Gradle properties file
-# OWASP Dependency-Check requires more heap during NVD database updates.
-org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
+# Memory for normal build tasks (tests, compilation, JaCoCo).
+# OWASP scan gets its own 2g allocation via GRADLE_OPTS in CI (see security-dependency-scan.yml).
+org.gradle.jvmargs=-Xmx1024m -XX:MaxMetaspaceSize=256m
 org.gradle.configureondemand=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 # Gradle properties file
-# Adjust JVM arguments to prevent memory issues
-org.gradle.jvmargs=-Xmx256m -XX:MaxMetaspaceSize=128m
+# OWASP Dependency-Check requires more heap during NVD database updates.
+org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
 org.gradle.configureondemand=false


### PR DESCRIPTION
Sécuriser l’application en automatisant la détection des vulnérabilités des dépendances avec OWASP Dependency-Check.

Changements :
- ajout du plugin OWASP Dependency-Check dans Gradle
- génération des rapports HTML et JSON
- seuil bloquant configuré sur CVSS >= 9.0
- ajout d’un workflow GitHub Actions dédié au scan sécurité
- séparation des étapes CI entre tests/couverture et scan OWASP
- allocation mémoire dédiée au scan OWASP uniquement
- mise à jour de la documentation README

Résultat :
- rapport OWASP généré avec succès
- 8 vulnérabilités détectées
- score CVSS maximum détecté : 7.5
- aucune vulnérabilité critique bloquante
- pipeline configurée pour échouer en cas de CVE critique

Validation  => 
.\gradlew.bat dependencyCheckAnalyze

Workflow CI ajouté => 
push
pull_request
scan planifié chaque lundi

Fichiers modifiés :
- build.gradle
- gradle.properties
- security-dependency-scan.yml
- README.md
